### PR TITLE
updated to add android-x components

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,11 +8,11 @@ androidExtensions {
 }
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     defaultConfig {
         applicationId "bg.devlabs.fastlist"
         minSdkVersion 19
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -23,17 +23,17 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    buildToolsVersion '28.0.1'
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:27.1.1'
+    //implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'com.android.support.constraint:constraint-layout:1.1.2'
-
-    implementation "com.android.support:recyclerview-v7:27.1.1"
+    //implementation 'com.android.support:recyclerview-v7:27.1.1'
+    implementation 'androidx.appcompat:appcompat:1.0.0-beta01'
     implementation 'androidx.core:core-ktx:0.3'
-
+    implementation 'androidx.recyclerview:recyclerview:1.0.0-beta01'
     implementation project(path: ':fast-list')
-
 }

--- a/app/src/main/java/com/list/rados/recyclerviewlibrary/MainActivity.kt
+++ b/app/src/main/java/com/list/rados/recyclerviewlibrary/MainActivity.kt
@@ -1,12 +1,14 @@
 package com.list.rados.recyclerviewlibrary
 
-import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
 import android.os.Handler
-import android.support.v7.widget.LinearLayoutManager
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.widget.toast
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.list.rados.fast_list.bind
 import com.list.rados.fast_list.update
+import com.list.rados.recyclerviewlibrary.R.id.*
 import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.android.synthetic.main.item.view.*
 import kotlinx.android.synthetic.main.item_second.view.*
@@ -21,6 +23,8 @@ class MainActivity : AppCompatActivity() {
 
         val list = listOf(Item("first", 2), Item("second", 2), Item("third", 1), Item("fourth", 1), Item("fifth", 1))
         val list2 = listOf(Item("first", 2), Item("third", 1), Item("fifth", 1), Item("sixth", 1))
+
+	    val recyclerView: RecyclerView = recycler_view
 
         recycler_view.bind(list, R.layout.item) { item: Item ->
             item_text.text = item.value

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,14 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.constraint.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
 </android.support.constraint.ConstraintLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,16 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.41'
+    ext.kotlin_version = '1.2.50'
     ext.dokka_version = '0.9.15'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.3.0-alpha02'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-android-extensions:$kotlin_version"
 
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'

--- a/fast-list/build.gradle
+++ b/fast-list/build.gradle
@@ -10,27 +10,21 @@ androidExtensions {
 }
 
 android {
-    compileSdkVersion 27
-
-
-
+    compileSdkVersion 28
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
-
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
-
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-
+    buildToolsVersion '28.0.1'
 }
 
 dokka {
@@ -39,16 +33,16 @@ dokka {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    //implementation 'com.android.support:appcompat-v7:28.0.0-alpha3'
+    implementation 'androidx.appcompat:appcompat:1.0.0-beta01'
+    implementation 'androidx.recyclerview:recyclerview:1.0.0-beta01'
+    //implementation 'com.android.support:recyclerview-v7:28.0.0-alpha3'
+    implementation 'androidx.core:core-ktx:0.3'
 
-    implementation 'com.android.support:appcompat-v7:27.1.1'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-
-    compileOnly "com.android.support:recyclerview-v7:27.1.1"
-    compileOnly 'androidx.core:core-ktx:0.3'
-
 }
 
 apply from: 'deploy.gradle'

--- a/fast-list/src/main/java/com/list/rados/fast_list/BaseListAndroidX.kt
+++ b/fast-list/src/main/java/com/list/rados/fast_list/BaseListAndroidX.kt
@@ -1,0 +1,128 @@
+package com.list.rados.fast_list
+
+import android.support.annotation.LayoutRes
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.android.extensions.LayoutContainer
+
+/**
+ * Created by Radoslav Yankov on 29.06.2018
+ * radoslavyankov@gmail.com
+ */
+
+/**
+ * Dynamic list bind function. It should be followed by one or multiple .map calls.
+ * @param items - Generic list of the items to be displayed in the list
+ */
+fun <T> RecyclerView.bind(items: List<T>): FastListAdapterAX<T> {
+    layoutManager = LinearLayoutManager(context)
+    return FastListAdapterAX(items.toMutableList(), this)
+}
+
+/**
+ * Simple list bind function.
+ * @param items - Generic list of the items to be displayed in the list
+ * @param singleLayout - The layout that will be used in the list
+ * @param singleBind - The "binding" function between the item and the layout. This is the standard "bind" function in traditional ViewHolder classes. It uses Kotlin Extensions
+ * so you can just use the XML names of the views inside your layout to address them.
+ */
+fun <T> RecyclerView.bind(items: List<T>, @LayoutRes singleLayout: Int = 0, singleBind: (View.(item: T) -> Unit)): FastListAdapterAX<T> {
+    layoutManager = LinearLayoutManager(context)
+    return FastListAdapterAX(items.toMutableList(), this
+    ).map(singleLayout, { true }, singleBind)
+}
+
+
+/**
+ * Updates the list using DiffUtils.
+ * @param newItems the new list which is to replace the old one.
+ *
+ * NOTICE: The comparator currently checks if items are literally the same. You can change that if you want,
+ * by changing the lambda in the function
+ */
+fun <T> RecyclerView.update(newItems: List<T>) {
+    (adapter as? FastListAdapter<T>)?.update(newItems) { o, n -> o == n }
+}
+
+
+open class FastListAdapterAX<T>(private var items: MutableList<T>, private var list: RecyclerView
+) : RecyclerView.Adapter<FastListViewHolderAX<T>>() {
+
+    private inner class BindMap(val layout: Int, var type: Int = 0, val bind: View.(item: T) -> Unit, val predicate: (item: T) -> Boolean)
+
+    private var bindMap = mutableListOf<BindMap>()
+    private var typeCounter = 0
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): FastListViewHolderAX<T> {
+        return bindMap.first { it.type == viewType }.let {
+            FastListViewHolderAX(LayoutInflater.from(parent.context).inflate(it.layout,
+                    parent, false), viewType)
+        }
+    }
+
+    override fun onBindViewHolder(holder: FastListViewHolderAX<T>, position: Int) {
+        val item = items.get(position)
+        holder.bind(item, bindMap.first { it.type == holder.holderType }.bind)
+    }
+
+    override fun getItemCount() = items.size
+
+    override fun getItemViewType(position: Int) = try {
+        bindMap.first { it.predicate(items[position]) }.type
+    } catch (e: Exception) {
+        0
+    }
+
+    /**
+     * The function used for mapping types to layouts
+     * @param layout - The ID of the XML layout of the given type
+     * @param predicate - Function used to sort the items. For example, a Type field inside your items class with different values for different types.
+     * @param bind - The "binding" function between the item and the layout. This is the standard "bind" function in traditional ViewHolder classes. It uses Kotlin Extensions
+     * so you can just use the XML names of the views inside your layout to address them.
+     */
+    fun map(@LayoutRes layout: Int, predicate: (item: T) -> Boolean, bind: View.(item: T) -> Unit): FastListAdapterAX<T> {
+        bindMap.add(BindMap(layout, typeCounter++, bind, predicate))
+        list.adapter = this
+        return this
+    }
+
+    /**
+     * Sets up a layout manager for the recycler view.
+     */
+    fun layoutManager(manager: RecyclerView.LayoutManager): FastListAdapterAX<T> {
+        list.layoutManager = manager
+        return this
+    }
+
+    fun update(newList: List<T>, compare: (T, T) -> Boolean) {
+        val diff = DiffUtil.calculateDiff(object : DiffUtil.Callback() {
+
+            override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+                return compare(items[oldItemPosition], newList[newItemPosition])
+            }
+
+            override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+                return items[oldItemPosition] == newList[newItemPosition]
+            }
+
+            override fun getOldListSize() = items.size
+
+            override fun getNewListSize() = newList.size
+        })
+        items = newList.toMutableList()
+        diff.dispatchUpdatesTo(this)
+    }
+
+}
+
+class FastListViewHolderAX<T>(override val containerView: View, val holderType: Int) : RecyclerView.ViewHolder(containerView), LayoutContainer {
+    fun bind(entry: T, func: View.(item: T) -> Unit) {
+        containerView.apply {
+            func(entry)
+        }
+    }
+}


### PR DESCRIPTION
I really like your fast-list repo and I want to use it in my repository. However, I am currently implementing the new Android Architecture components from Android JetPack, where many UI elements have been renewed. In the case of this library, RecyclerView has been updated and now lives in another package, where your extension functions don't apply. So I wanted to see if I could modify your extensions to fit the new libraries. I also had to modify the gradle files to make this work. An issue is, however, that in a single module you cannot use both the old one and the new one; the libraries conflict in the gradle. For comparison and for usefulness of this pull request, I created a new BaseListAndroidX.kt which implements the new components and left the old one alone. It may be appropriate to have two separate repos or a single repo with multiple modules where each one has its own gradle and one module is legacy and one is JetPack.

@RadoslavYankov 